### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/Source/LogFramework.Core/LogFramework.Core.csproj
+++ b/Source/LogFramework.Core/LogFramework.Core.csproj
@@ -13,6 +13,14 @@
     <RepositoryUrl>https://github.com/scott-mcdonald/LogFramework</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageIconUrl>https://raw.githubusercontent.com/scott-mcdonald/LogFramework/master/LogoIcon.png</PackageIconUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
 </Project>

--- a/Source/LogFramework.Microsoft.Extensions.Logging/LogFramework.Microsoft.Extensions.Logging.csproj
+++ b/Source/LogFramework.Microsoft.Extensions.Logging/LogFramework.Microsoft.Extensions.Logging.csproj
@@ -13,7 +13,15 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>microsoft.extensions.logging .net cross-platform logging facade framework</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/scott-mcdonald/LogFramework/master/LogoIcon.png</PackageIconUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />

--- a/Source/LogFramework.NLog/LogFramework.NLog.csproj
+++ b/Source/LogFramework.NLog/LogFramework.NLog.csproj
@@ -13,7 +13,15 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>nlog .net cross-platform logging facade framework</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/scott-mcdonald/LogFramework/master/LogoIcon.png</PackageIconUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.6.0" />

--- a/Source/LogFramework.Serilog/LogFramework.Serilog.csproj
+++ b/Source/LogFramework.Serilog/LogFramework.Serilog.csproj
@@ -13,7 +13,15 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>serilog .net cross-platform logging facade framework</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/scott-mcdonald/LogFramework/master/LogoIcon.png</PackageIconUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.8.0" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
